### PR TITLE
Major performance improvement; Reduced unnecessary md5 calculation

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -1,4 +1,3 @@
-import time
 import webbrowser
 from typing import Mapping
 
@@ -67,7 +66,11 @@ class AWSApiMixin:
 
     def test_and_set_credentials(self, kwargs):
         try:
-            response = test_credentials(kwargs["access_key_id"], kwargs["secret_access_key"], kwargs["region_name"])
+            response = test_credentials(
+                kwargs["access_key_id"],
+                kwargs["secret_access_key"],
+                kwargs["region_name"]
+            )
             if response.get("ok"):
                 self.set_configs({
                     'AWS_ACCESS_KEY_ID': kwargs["access_key_id"],
@@ -92,21 +95,30 @@ class SyncerApiMixin:
     # Syncer
     def scan(self, kwargs):
         if not self.syncer.has_bucket_name():
-            self.syncer.set_bucket_name(self.config_manager.get("DEFAULT_BUCKET_NAME"))
+            self.syncer.set_bucket_name(
+                self.config_manager.get("DEFAULT_BUCKET_NAME")
+            )
 
-        path = self.config_manager.get("TARGET_PATH") if kwargs.get("path") is None else kwargs["path"]
+        path = self.config_manager.get("TARGET_PATH") \
+            if kwargs.get("path") is None \
+            else kwargs["path"]
         logger.info(f"Scanning directory: {path}")
-        return self.syncer.scan(path)
+
+        return self.syncer.scan(path, recursive=False)
 
     def get_sync_status(self, kwargs):
         files = self.syncer.scan(recursive=True)
-        synced = len(list(filter(lambda f: len(f) > 2 and f[2] == "NOT_UPLOADED", files))) == 0
+        synced = len(
+            list(
+                filter(lambda f: len(f) > 2 and f[2] in ("NOT_UPLOADED", "NOT_SYNCED"), files)
+            )
+        ) == 0
         logger.info(f"Target path scanned. Sync status: {'all synced' if synced else 'not synced'}")
+
         return {"synced": synced}
 
     def sync(self, kwargs):
-        path = self.config_manager.get("TARGET_PATH")
-        return self.syncer.sync(path)
+        return self.syncer.sync()
 
 
 class DownloaderApiMixin:
@@ -127,8 +139,15 @@ class CurrentLogMixin:
         self._current_log = value
 
 
-class PFSApi(CurrentLogMixin, DownloaderApiMixin, SyncerApiMixin, AWSApiMixin, ConfigManagerApiMixin, CommonApiMixin,
-             FileApiMixin):
+class PFSApi(
+    CurrentLogMixin,
+    DownloaderApiMixin,
+    SyncerApiMixin,
+    AWSApiMixin,
+    ConfigManagerApiMixin,
+    CommonApiMixin,
+    FileApiMixin
+):
     """
     Caveat:
     - JS will send at least 1 positional argument.(None,)

--- a/core/meta.py
+++ b/core/meta.py
@@ -1,0 +1,63 @@
+import os
+import sqlite3
+from typing import Union, Tuple
+
+
+class MetaStore:
+    def __init__(self, db_path, target_path, db_name=".pfs_metadata"):
+        # Keep metastore backed up in the S3 bucket
+        self._store_path = os.path.join(db_path, db_name)
+
+        # Connecting it will auto create an empty DB,
+        # if not already exists
+        self._conn = sqlite3.connect(self._store_path)
+
+        # Initialize DB if necessary
+        if not self._is_db_initialized():
+            self._initialize_db()
+
+    def _is_db_initialized(self):
+        """
+        Check if DB is created with tables initialized
+        """
+        cur = self._conn.cursor()
+        cur.execute(''' 
+            SELECT count(name) 
+            FROM sqlite_master 
+            WHERE type='table' AND name='last_sync' 
+        ''')
+        record = cur.fetchone()
+        if record and len(record) > 0 and record[0] == 1:
+            return True
+        return False
+
+    def _initialize_db(self):
+        """
+        Create db file and tables
+        """
+        cur = self._conn.cursor()
+        cur.execute('''
+        CREATE TABLE last_sync (
+            rel_file_path varchar,
+            last_synced float 
+        )
+        ''')
+        self._conn.commit()
+
+    def get_last_synced(self, rel_file_path) -> Tuple[str, Union[float, None]]:
+        cur = self._conn.cursor()
+        cur.execute('''
+            SELECT last_synced
+            FROM last_sync
+            WHERE rel_file_path=?
+        ''', (rel_file_path,))
+        record = cur.fetchone()
+        return record or (rel_file_path, None)
+
+    def set_last_synced(self, rel_file_path, last_synced):
+        cur = self._conn.cursor()
+        cur.execute('''
+                INSERT INTO last_sync(rel_file_path, last_synced)
+                VALUES (?, ?)
+                ''', (rel_file_path, last_synced))
+        self._conn.commit()

--- a/core/meta.py
+++ b/core/meta.py
@@ -7,14 +7,26 @@ class MetaStore:
     def __init__(self, db_path, target_path, db_name=".pfs_metadata"):
         # Keep metastore backed up in the S3 bucket
         self._store_path = os.path.join(db_path, db_name)
+        self._store_rel_path = os.path.relpath(self._store_path, target_path)
 
         # Connecting it will auto create an empty DB,
         # if not already exists
-        self._conn = sqlite3.connect(self._store_path)
+        self._conn = sqlite3.connect(self._store_path, check_same_thread=False)
 
         # Initialize DB if necessary
         if not self._is_db_initialized():
             self._initialize_db()
+
+    @property
+    def path(self):
+        return self._store_path
+
+    @property
+    def rel_path(self):
+        return self._store_rel_path
+
+    def is_metastore(self, abs_path):
+        return self._store_path == abs_path
 
     def _is_db_initialized(self):
         """
@@ -47,17 +59,20 @@ class MetaStore:
     def get_last_synced(self, rel_file_path) -> Tuple[str, Union[float, None]]:
         cur = self._conn.cursor()
         cur.execute('''
-            SELECT last_synced
+            SELECT rel_file_path, last_synced
             FROM last_sync
             WHERE rel_file_path=?
         ''', (rel_file_path,))
         record = cur.fetchone()
-        return record or (rel_file_path, None)
+        cur.close()
+        return record or (rel_file_path, 0.0)
 
     def set_last_synced(self, rel_file_path, last_synced):
+        # FIXME Should be Upsert
         cur = self._conn.cursor()
         cur.execute('''
                 INSERT INTO last_sync(rel_file_path, last_synced)
                 VALUES (?, ?)
                 ''', (rel_file_path, last_synced))
         self._conn.commit()
+        cur.close()

--- a/core/syncer.py
+++ b/core/syncer.py
@@ -2,8 +2,8 @@ import glob
 import multiprocessing
 import os
 import time
-
 from os.path import isfile, isdir
+
 from botocore.exceptions import ClientError
 
 from core.aws.s3 import S3Client
@@ -22,7 +22,8 @@ class Syncer:
         self._max_workers = max_workers or configs.MAX_CONCURRENCY
 
         self._client = s3_client or S3Client(self._bucket_name)
-        self._meta_store = MetaStore(db_path=self._target_path, target_path=self._target_path)
+        self._meta_store = MetaStore(db_path=self._target_path,
+                                     target_path=self._target_path)
 
         self._dry_run = False
 
@@ -39,96 +40,109 @@ class Syncer:
 
         target_directory = os.path.abspath(path)
         logger.info(f"Target directory: {target_directory}")
-        os.chdir(target_directory)
+
+        # Always start from the target path (aka the location of the bucket)
+        os.chdir(self._target_path)
 
         # Derive object name by diffing current_directory and root_path
         object_prefix = os.path.relpath(target_directory, self._target_path)
         object_prefix = f"{object_prefix}/" if object_prefix is not "." else ""
 
-        files_iter = glob.iglob(file_pattern, recursive=recursive)
+        files_iter = glob.iglob(f"{object_prefix}{file_pattern}", recursive=recursive)
         files = []
-        for file in files_iter:
-            if isdir(file):
-                files.append((file, 'DIRECTORY'))
+        for rel_file_path in files_iter:
+            if isdir(rel_file_path):
+                files.append((os.path.basename(rel_file_path), 'DIRECTORY'))
 
-            if isfile(file):
-                # 1. Check last synced
-                if self._get_last_synced(file) >= get_last_modified(file):
-                    files.append((file, 'FILE', 'SYNCED'))
+            elif self._is_metastore(rel_file_path):
+                # Ignore metastore file
+                pass
 
-                # 2. Check if file is in bucket
-                elif not self._is_object_exists(f"{object_prefix}{file}"):
+            elif isfile(rel_file_path):
+                # 1. Check if file is in bucket
+                if not self._is_object_exists(rel_file_path):
                     # File not in Bucket
-                    files.append((file, 'FILE', 'NOT_UPLOADED'))
+                    files.append((os.path.basename(rel_file_path), 'FILE', 'NOT_UPLOADED'))
+
+                # 2. Check last synced
+                elif self._get_last_synced(rel_file_path) >= \
+                        get_last_modified(abs_file_path=os.path.abspath(rel_file_path)):
+                    files.append((os.path.basename(rel_file_path), 'FILE', 'SYNCED'))
 
                 # 3. Check if md5sum match
                 else:
                     # File is in Bucket
-                    md5sum_local = calc_md5sum(file)
+                    md5sum_local = calc_md5sum(rel_file_path)
 
-                    metadata_remote = self._get_object_metadata(f"{object_prefix}{file}")
+                    metadata_remote = self._get_object_metadata(rel_file_path)
                     md5sum_remote = metadata_remote.get('md5sum', None)
 
                     if md5sum_local != md5sum_remote:
                         # File is not synced
-                        files.append((file, 'FILE', 'NOT_SYNCED'))
+                        files.append((os.path.basename(rel_file_path), 'FILE', 'NOT_SYNCED'))
                     else:
                         # File is synced
-                        files.append((file, 'FILE', 'SYNCED'))
+                        # Update last_synced, since at this point,
+                        # it is apparent that it has been upload
+                        # but the entry is missing from metastore
+                        self._set_last_synced(rel_file_path=rel_file_path)
+                        files.append((os.path.basename(rel_file_path), 'FILE', 'SYNCED'))
 
         return files
 
-    def sync(self, path=None, dry_run=False, recursive=True, file_pattern="**"):
+    def sync(self, dry_run=False, recursive=True, file_pattern="**"):
         """
         Scan and upload files in `path` if md5 mismatch
         """
         self._dry_run = dry_run
         logger.info("Dry run is {}".format("on" if dry_run else "off"))
 
-        # Set path
-        if path is None:
-            path = self._target_path
-
         # Navigate to target directory
-        target_directory = os.path.abspath(path)
+        target_directory = os.path.abspath(self._target_path)
         logger.info(f"Target directory: {target_directory}")
         os.chdir(target_directory)
 
         # Create uploaded worker
-        _upload_workers = [multiprocessing.Process(target=self._upload_file)
+        _upload_workers = [multiprocessing.Process(target=self._upload_file_task)
                            for _ in range(self._max_workers)]
         [p.start() for p in _upload_workers]
 
         # Scan directories
         files_iter = glob.iglob(file_pattern, recursive=recursive)
-        for file in files_iter:
-            if isfile(file):
+        for rel_file_path in files_iter:
+            if self._is_metastore(rel_file_path):
+                # Ignore metastore file
+                pass
+
+            elif isfile(rel_file_path):
                 # 1. Get last synced
-                if self._get_last_synced(file) >= get_last_modified(file):
+                if not self._is_object_exists(rel_file_path):
+                    logger.debug("File doesn't exist, queuing file.. ({})".format(rel_file_path))
+                    md5sum_local = calc_md5sum(rel_file_path)
+                    self._upload_queue.put((rel_file_path, md5sum_local))
+                    self._files_to_be_uploaded.release()
+
+                # 2. File is not in bucket -> Upload and set last_synced
+                elif self._get_last_synced(rel_file_path) >= \
+                        get_last_modified(abs_file_path=os.path.abspath(rel_file_path)):
                     # No need to sync -> Do nothing
                     pass
 
+                # 3. File is in the bucket -> Check if md5sum match
                 else:
-                    md5sum_local = calc_md5sum(file)
+                    md5sum_local = calc_md5sum(rel_file_path)
+                    metadata_remote = self._get_object_metadata(rel_file_path)
+                    md5sum_remote = metadata_remote.get('md5sum', None)
 
-                    # 2. Check if file is in bucket
-                    if not self._is_object_exists(file):
-                        # File not in Bucket
-                        logger.debug("File doesn't exist, queuing file.. ({})".format(file))
-                        self._upload_queue.put((file, md5sum_local))
+                    if md5sum_local != md5sum_remote:  # Upload file if sync required
+                        logger.debug("Etags mismatched. File is being queued ({})".format(rel_file_path))
+                        self._upload_queue.put((rel_file_path, md5sum_local))
                         self._files_to_be_uploaded.release()
 
-                    # 3. Check if md5sum match
                     else:
-                        # File is in Bucket
-                        metadata_remote = self._get_object_metadata(file)
-                        md5sum_remote = metadata_remote.get('md5sum', None)
-                        if md5sum_local != md5sum_remote:  # Upload file if sync required
-                            logger.debug("Etags mismatched. File is being queued ({})".format(file))
-                            self._upload_queue.put((file, md5sum_local))
-                            self._files_to_be_uploaded.release()
+                        self._set_last_synced(rel_file_path=rel_file_path)
 
-        # Joining queues and upload workers
+        # Joining queues and workers
         for _ in range(self._max_workers):
             self._upload_queue.put(None)
             self._files_to_be_uploaded.release()
@@ -142,15 +156,23 @@ class Syncer:
         (_, last_synced) = self._meta_store.get_last_synced(
             rel_file_path=rel_file_path
         )
-        return last_synced or 0.0
+        return last_synced
 
-    def _set_last_synced(self, rel_file_path, last_synced):
+    def _set_last_synced(self, rel_file_path, last_synced="CURRENT_TIME"):
         """
         Set sync status in MetaStore
         """
+        if not last_synced or last_synced == "CURRENT_TIME":
+            last_synced = time.time()
+
         return self._meta_store.set_last_synced(
             rel_file_path=rel_file_path,
             last_synced=last_synced
+        )
+
+    def _is_metastore(self, rel_file_path):
+        return self._meta_store.is_metastore(
+            os.path.join(self._target_path, rel_file_path)
         )
 
     def _is_object_exists(self, rel_file_path) -> bool:
@@ -163,24 +185,27 @@ class Syncer:
         else:
             return True
 
-    def _upload_file(self):
+    def _upload_file_task(self):
         while self._files_to_be_uploaded.acquire():
             queue_item = self._upload_queue.get()
             if queue_item is None:
                 break  # A sentinel value to quit the loop
 
-            file, md5sum = queue_item
+            rel_file_path, md5sum = queue_item
 
-            if self._dry_run:
-                return
-
-            logger.info(f"Uploading file... ({file})")
-            self._client.put_object(object_key=file,
-                                    file_path=self._get_abs_file_path(file),
-                                    metadata={'md5sum': md5sum})
-            self._set_last_synced(rel_file_path=file, last_synced=time.time())
-            logger.info(f"File is uploaded! ({file})")
+            self._upload_file(rel_file_path=rel_file_path, md5sum=md5sum)
             self._upload_queue.task_done()
+
+    def _upload_file(self, rel_file_path, md5sum):
+        if self._dry_run:
+            return
+
+        logger.info(f"Uploading file... ({rel_file_path})")
+        self._client.put_object(object_key=rel_file_path,
+                                file_path=self._get_abs_file_path(rel_file_path),
+                                metadata={'md5sum': md5sum})
+        self._set_last_synced(rel_file_path=rel_file_path)
+        logger.info(f"File is uploaded! ({rel_file_path})")
 
     def _get_object_metadata(self, rel_file_path):
         return self._client.get_object(object_key=rel_file_path).metadata

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,17 +1,18 @@
 import hashlib
+import os
 
 from core.configs import configs
 from core.logging import logger
 
 
-def calc_md5sum(file):
+def calc_md5sum(rel_file_path):
     """
     Calculate md5sum
     Read chunk by chunk to reduce memory
     """
-    logger.debug("Calculating md5sum for `{}`".format(file))
+    logger.debug("Calculating md5sum for `{}`".format(rel_file_path))
     hasher = hashlib.md5()
-    with open(file, 'rb') as afile:
+    with open(rel_file_path, 'rb') as afile:
         buf = afile.read(configs.READ_CHUNK_SIZE)
         while len(buf) > 0:
             hasher.update(buf)
@@ -19,9 +20,8 @@ def calc_md5sum(file):
     return '{}'.format(hasher.hexdigest())
 
 
-def get_last_modified(file):
+def get_last_modified(abs_file_path):
     """
-    TODO
     get last modified timestamp of file
     """
-    pass
+    return os.path.getmtime(abs_file_path)

--- a/core/utils.py
+++ b/core/utils.py
@@ -6,6 +6,7 @@ from core.logging import logger
 
 def calc_md5sum(file):
     """
+    Calculate md5sum
     Read chunk by chunk to reduce memory
     """
     logger.debug("Calculating md5sum for `{}`".format(file))
@@ -16,3 +17,11 @@ def calc_md5sum(file):
             hasher.update(buf)
             buf = afile.read(configs.READ_CHUNK_SIZE)
     return '{}'.format(hasher.hexdigest())
+
+
+def get_last_modified(file):
+    """
+    TODO
+    get last modified timestamp of file
+    """
+    pass

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import webview
 
 from core.api import PFSApi
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
 from core.logging import add_stream_handler, add_jsapi_handler
 

--- a/view/src/pages/Home.vue
+++ b/view/src/pages/Home.vue
@@ -12,8 +12,12 @@
                 <p><small>{{ currentDir }}</small></p>
             </vs-col>
             <vs-col vs-w="1" vs-type="flex" vs-justify="flex-end" vs-align="flex-end">
-                <vs-button v-if="showSyncButton" id="sync-button" class="vs-con-loading__container" color="primary" icon="sync" @click="sync"></vs-button>
-                <vs-button v-if="showScanButton" id="scan-button" class="vs-con-loading__container" color="primary" icon="search" @click="getSyncStatus"></vs-button>
+                <vs-tooltip v-if="showSyncButton" text="Start syncing">
+                    <vs-button id="sync-button" class="vs-con-loading__container" color="primary" icon="sync" @click="sync"></vs-button>
+                </vs-tooltip>
+                <vs-tooltip v-if="showScanButton" text="Scan files">
+                    <vs-button id="scan-button" class="vs-con-loading__container" color="primary" icon="search" @click="getSyncStatus"></vs-button>
+                </vs-tooltip>
             </vs-col>
         </vs-row>
         <vs-row id="row-file-list" vs-type="flex" vs-justify="center" vs-align="flex-start">


### PR DESCRIPTION
In this PR:
- Syncer now uses a metastore locally to keep track of last synced timestamp. It will compare the timestamp from the metastore before deciding whether md5sum calculation is required. This largely reduced unnecessary Disk I/O and performance. Under a basic benchmarking using `cProfile`, the performance improvement is around 35-49%

Close #12 